### PR TITLE
Serialization no longer changes torrent hash.

### DIFF
--- a/common/src/main/java/com/turn/ttorrent/common/TorrentMetadata.java
+++ b/common/src/main/java/com/turn/ttorrent/common/TorrentMetadata.java
@@ -64,7 +64,12 @@ public interface TorrentMetadata extends TorrentHash {
   int getPiecesCount();
 
   /**
-   * @return The filename of the directory in which to store all the files
+   * @return The filename of single file or the directory in which to store all the files
+   */
+  String getName();
+
+  /**
+   * @return The filename of the directory in which to store all the files, null if it is a single file
    */
   String getDirectoryName();
 

--- a/common/src/main/java/com/turn/ttorrent/common/TorrentMetadataImpl.java
+++ b/common/src/main/java/com/turn/ttorrent/common/TorrentMetadataImpl.java
@@ -1,6 +1,5 @@
 package com.turn.ttorrent.common;
 
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -15,6 +14,7 @@ public class TorrentMetadataImpl implements TorrentMetadata {
   private final String myComment;
   private final String myCreatedBy;
   private final String myName;
+  private final String myDirName;
   private final List<TorrentFile> myFiles;
   private final int myPieceCount;
   private final int myPieceLength;
@@ -28,6 +28,7 @@ public class TorrentMetadataImpl implements TorrentMetadata {
                       String comment,
                       String createdBy,
                       String name,
+                      String dirName,
                       List<TorrentFile> files,
                       int pieceCount,
                       int pieceLength,
@@ -39,6 +40,7 @@ public class TorrentMetadataImpl implements TorrentMetadata {
     myComment = comment;
     myCreatedBy = createdBy;
     myName = name;
+    myDirName = dirName;
     myFiles = files;
     myPieceCount = pieceCount;
     myPieceLength = pieceLength;
@@ -47,9 +49,15 @@ public class TorrentMetadataImpl implements TorrentMetadata {
   }
 
   @Override
-  public String getDirectoryName() {
+  public String getName() {
     return myName;
   }
+
+  @Override
+  public String getDirectoryName() {
+    return myDirName;
+  }
+
 
   @Override
   public List<TorrentFile> getFiles() {

--- a/common/src/main/java/com/turn/ttorrent/common/TorrentParser.java
+++ b/common/src/main/java/com/turn/ttorrent/common/TorrentParser.java
@@ -55,9 +55,10 @@ public class TorrentParser {
 
     final boolean torrentContainsManyFiles = infoTable.get(FILES) != null;
 
-    final String dirName = getRequiredValueOrThrowException(infoTable, NAME).getString();
+    final String name = getRequiredValueOrThrowException(infoTable, NAME).getString();
+    final String dirName = torrentContainsManyFiles ? name : null;
 
-    final List<TorrentFile> files = parseFiles(infoTable, torrentContainsManyFiles, dirName);
+    final List<TorrentFile> files = parseFiles(infoTable, torrentContainsManyFiles, name);
 
     if (piecesHashes.length % Constants.PIECE_HASH_SIZE != 0)
       throw new InvalidBEncodingException("Incorrect size of pieces hashes");
@@ -78,6 +79,7 @@ public class TorrentParser {
             creationDate,
             comment,
             createdBy,
+            name,
             dirName,
             files,
             piecesCount,

--- a/common/src/main/java/com/turn/ttorrent/common/TorrentSerializer.java
+++ b/common/src/main/java/com/turn/ttorrent/common/TorrentSerializer.java
@@ -36,18 +36,13 @@ public class TorrentSerializer {
       infoTable.put(PRIVATE, new BEValue(1));
     }
 
-    infoTable.put(NAME, new BEValue(metadata.getDirectoryName()));
-    boolean needsMultiFileMode;
-    if (metadata.getFiles().size() != 1) {
-      needsMultiFileMode = true;
-    } else {
-      // if the only file has a custom path (i.e. not at the root) we must keep that
-      TorrentFile onlyFile = metadata.getFiles().get(0);
-      List<String> filePathInSingleMode = Collections.singletonList(metadata.getDirectoryName());
-      needsMultiFileMode = !filePathInSingleMode.equals(onlyFile.relativePath);
-    }
+    infoTable.put(NAME, new BEValue(metadata.getName()));
 
-    if (needsMultiFileMode) {
+    if (metadata.getFiles().size() == 1 && metadata.getDirectoryName() == null) {
+      final TorrentFile torrentFile = metadata.getFiles().get(0);
+      infoTable.put(FILE_LENGTH, new BEValue(torrentFile.size));
+      putOptionalIfPresent(infoTable, MD5_SUM, torrentFile.md5Hash);
+    } else {
       List<BEValue> files = new ArrayList<BEValue>();
       for (TorrentFile torrentFile : metadata.getFiles()) {
         Map<String, BEValue> entry = new HashMap<String, BEValue>();
@@ -57,10 +52,6 @@ public class TorrentSerializer {
         files.add(new BEValue(entry));
       }
       infoTable.put(FILES, new BEValue(files));
-    } else {
-      final TorrentFile torrentFile = metadata.getFiles().get(0);
-      infoTable.put(FILE_LENGTH, new BEValue(torrentFile.size));
-      putOptionalIfPresent(infoTable, MD5_SUM, torrentFile.md5Hash);
     }
 
     mapMetadata.put(INFO_TABLE, new BEValue(infoTable));

--- a/common/src/main/java/com/turn/ttorrent/common/creation/MetadataBuilder.java
+++ b/common/src/main/java/com/turn/ttorrent/common/creation/MetadataBuilder.java
@@ -355,7 +355,9 @@ public class MetadataBuilder {
     Map<String, BEValue> info = new HashMap<String, BEValue>();
     info.put(PIECE_LENGTH, new BEValue(pieceLength));
     info.put(PIECES, concatHashes(hashingResult.getHashes()));
-    info.put(PRIVATE, new BEValue(isPrivate ? 1 : 0));
+    if (isPrivate) {
+      info.put(PRIVATE, new BEValue(1));
+    }
     info.put(NAME, new BEValue(name));
     if (isSingleMode) {
       Long sourceSize = hashingResult.getSourceSizes().get(0);

--- a/common/src/test/java/com/turn/ttorrent/common/TorrentParserTest.java
+++ b/common/src/test/java/com/turn/ttorrent/common/TorrentParserTest.java
@@ -55,7 +55,7 @@ public class TorrentParserTest {
 
     assertEquals(torrentMetadata.getPieceLength(), 4);
     assertEquals(torrentMetadata.getAnnounce(), "http://localhost/announce");
-    assertEquals(torrentMetadata.getDirectoryName(), "test.file");
+    assertEquals(torrentMetadata.getName(), "test.file");
     assertNull(torrentMetadata.getAnnounceList());
 
     List<BEValue> announceList = new ArrayList<BEValue>();

--- a/common/src/test/java/com/turn/ttorrent/common/creation/MetadataBuilderTest.java
+++ b/common/src/test/java/com/turn/ttorrent/common/creation/MetadataBuilderTest.java
@@ -155,7 +155,20 @@ public class MetadataBuilderTest {
     TorrentMetadata metadata = new TorrentParser().parse(binary);
     byte[] backToBinary = new TorrentSerializer().serialize(metadata);
     assertEquals(binary, backToBinary,
-            "\n Before:" + Hex.encodeHexString(binary) +
-                    " \n After :" + Hex.encodeHexString(backToBinary));
+                    "\n Before:" + printable(binary) +
+                    " \n After :" + printable(backToBinary) + "\n"
+    );
+  }
+
+  private static String printable(byte[] binary) {
+    StringBuilder buf = new StringBuilder();
+    for (byte b : binary) {
+      if ((' ' <= b) && (b <= 'z')) {
+        buf.append((char) b);
+      } else {
+        buf.append('.');
+      }
+    }
+    return buf.toString();
   }
 }

--- a/common/src/test/java/com/turn/ttorrent/common/creation/MetadataBuilderTest.java
+++ b/common/src/test/java/com/turn/ttorrent/common/creation/MetadataBuilderTest.java
@@ -22,7 +22,6 @@ import com.turn.ttorrent.common.TorrentMetadata;
 import com.turn.ttorrent.common.TorrentParser;
 import com.turn.ttorrent.common.TorrentSerializer;
 import com.turn.ttorrent.common.TorrentUtils;
-import org.apache.commons.codec.binary.Hex;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -57,6 +56,32 @@ public class MetadataBuilderTest {
       path.append("/").append(iterator.next().getString());
     }
     assertEquals(path.toString(), "path/some_file");
+
+    assertConsistentWithSerializer(builder.buildBinary());
+    assertConsistentWithSerializer(builder.build());
+  }
+
+  public void testMultiFileModeWithOneFileSameName() throws IOException {
+    MetadataBuilder builder = new MetadataBuilder()
+            .setDirectoryName("abc")
+            .addDataSource(new ByteArrayInputStream(new byte[]{1, 2}), "abc", true);
+    Map<String, BEValue> map = builder.buildBEP().getMap();
+    Map<String, BEValue> info = map.get(INFO_TABLE).getMap();
+    assertEquals(info.get(NAME).getString(), "abc");
+    List<BEValue> files = info.get(FILES).getList();
+    assertEquals(files.size(), 1);
+    Map<String, BEValue> file = files.get(0).getMap();
+    assertEquals(file.get(FILE_LENGTH).getInt(), 2);
+
+    StringBuilder path = new StringBuilder();
+    Iterator<BEValue> iterator = file.get(FILE_PATH).getList().iterator();
+    if (iterator.hasNext()) {
+      path = new StringBuilder(iterator.next().getString());
+    }
+    while (iterator.hasNext()) {
+      path.append("/").append(iterator.next().getString());
+    }
+    assertEquals(path.toString(), "abc");
 
     assertConsistentWithSerializer(builder.buildBinary());
     assertConsistentWithSerializer(builder.build());

--- a/common/src/test/java/com/turn/ttorrent/common/creation/MetadataBuilderTest.java
+++ b/common/src/test/java/com/turn/ttorrent/common/creation/MetadataBuilderTest.java
@@ -18,7 +18,11 @@ package com.turn.ttorrent.common.creation;
 
 import com.turn.ttorrent.Constants;
 import com.turn.ttorrent.bcodec.BEValue;
+import com.turn.ttorrent.common.TorrentMetadata;
+import com.turn.ttorrent.common.TorrentParser;
+import com.turn.ttorrent.common.TorrentSerializer;
 import com.turn.ttorrent.common.TorrentUtils;
+import org.apache.commons.codec.binary.Hex;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
@@ -33,10 +37,10 @@ import static org.testng.Assert.assertNull;
 public class MetadataBuilderTest {
 
   public void testMultiFileModeWithOneFile() throws IOException {
-    Map<String, BEValue> map = new MetadataBuilder()
+    MetadataBuilder builder = new MetadataBuilder()
             .setDirectoryName("root")
-            .addDataSource(new ByteArrayInputStream(new byte[]{1, 2}), "path/some_file", true)
-            .buildBEP().getMap();
+            .addDataSource(new ByteArrayInputStream(new byte[]{1, 2}), "path/some_file", true);
+    Map<String, BEValue> map = builder.buildBEP().getMap();
     Map<String, BEValue> info = map.get(INFO_TABLE).getMap();
     assertEquals(info.get(NAME).getString(), "root");
     List<BEValue> files = info.get(FILES).getList();
@@ -53,11 +57,14 @@ public class MetadataBuilderTest {
       path.append("/").append(iterator.next().getString());
     }
     assertEquals(path.toString(), "path/some_file");
+
+    assertConsistentWithSerializer(builder.buildBinary());
+    assertConsistentWithSerializer(builder.build());
   }
 
   public void testBuildWithSpecifiedHashes() throws IOException {
     byte[] expectedHash = TorrentUtils.calculateSha1Hash(new byte[]{1, 2, 3});
-    Map<String, BEValue> metadata = new MetadataBuilder()
+    MetadataBuilder builder = new MetadataBuilder()
             .setPiecesHashesCalculator(new PiecesHashesCalculator() {
               @Override
               public HashingResult calculateHashes(List<DataSourceHolder> sources, int pieceSize) {
@@ -69,23 +76,26 @@ public class MetadataBuilderTest {
                     Collections.singletonList("file"),
                     Collections.singletonList(42L))
             .setPieceLength(512)
-            .setTracker("http://localhost:12346")
-            .buildBEP().getMap();
+            .setTracker("http://localhost:12346");
+    Map<String, BEValue> metadata = builder.buildBEP().getMap();
 
     assertEquals(metadata.get(ANNOUNCE).getString(), "http://localhost:12346");
     Map<String, BEValue> info = metadata.get(INFO_TABLE).getMap();
     assertEquals(info.get(PIECES).getBytes(), expectedHash);
     assertEquals(info.get(NAME).getString(), "file");
     assertEquals(info.get(FILE_LENGTH).getLong(), 42);
+
+    assertConsistentWithSerializer(builder.buildBinary());
+    assertConsistentWithSerializer(builder.build());
   }
 
   public void testSingleFile() throws IOException {
 
     byte[] data = {1, 2, 12, 4, 5};
-    Map<String, BEValue> metadata = new MetadataBuilder()
+    MetadataBuilder builder = new MetadataBuilder()
             .addDataSource(new ByteArrayInputStream(data), "singleFile.txt", true)
-            .setTracker("http://localhost:12346")
-            .buildBEP().getMap();
+            .setTracker("http://localhost:12346");
+    Map<String, BEValue> metadata = builder.buildBEP().getMap();
     assertEquals(metadata.get(ANNOUNCE).getString(), "http://localhost:12346");
     assertNull(metadata.get(CREATION_DATE_SEC));
     assertNull(metadata.get(COMMENT));
@@ -98,17 +108,19 @@ public class MetadataBuilderTest {
     assertEquals(info.get(FILE_LENGTH).getInt(), data.length);
     assertEquals(info.get(NAME).getString(), "singleFile.txt");
 
+    assertConsistentWithSerializer(builder.buildBinary());
+    assertConsistentWithSerializer(builder.build());
   }
 
   public void testMultiFileWithOneFileValues() throws IOException {
 
     byte[] data = {34, 2, 12, 4, 5};
     List<String> paths = Arrays.asList("unix/path", "win\\path");
-    Map<String, BEValue> metadata = new MetadataBuilder()
+    MetadataBuilder builder = new MetadataBuilder()
             .addDataSource(new ByteArrayInputStream(data), paths.get(0), true)
             .addDataSource(new ByteArrayInputStream(data), paths.get(1), true)
-            .setDirectoryName("downloadDirName")
-            .buildBEP().getMap();
+            .setDirectoryName("downloadDirName");
+    Map<String, BEValue> metadata = builder.buildBEP().getMap();
 
     Map<String, BEValue> info = metadata.get(INFO_TABLE).getMap();
     assertEquals(info.get(PIECES).getBytes().length, Constants.PIECE_HASH_SIZE);
@@ -131,5 +143,19 @@ public class MetadataBuilderTest {
       }
     }
 
+    assertConsistentWithSerializer(builder.buildBinary());
+    assertConsistentWithSerializer(builder.build());
+  }
+
+  private static void assertConsistentWithSerializer(TorrentMetadata metadata) throws IOException {
+    assertConsistentWithSerializer(new TorrentSerializer().serialize(metadata));
+  }
+
+  private static void assertConsistentWithSerializer(byte[] binary) throws IOException {
+    TorrentMetadata metadata = new TorrentParser().parse(binary);
+    byte[] backToBinary = new TorrentSerializer().serialize(metadata);
+    assertEquals(binary, backToBinary,
+            "\n Before:" + Hex.encodeHexString(binary) +
+                    " \n After :" + Hex.encodeHexString(backToBinary));
   }
 }

--- a/ttorrent-client/src/main/java/com/turn/ttorrent/client/CommunicationManager.java
+++ b/ttorrent-client/src/main/java/com/turn/ttorrent/client/CommunicationManager.java
@@ -767,7 +767,7 @@ public class CommunicationManager implements AnnounceResponseListener, PeerActiv
             isTorrentComplete = torrent.isComplete();
 
             if (isTorrentComplete) {
-              logger.info("Download of {} complete.", torrent.getDirectoryName());
+              logger.info("Download of {} complete.", torrent.getName());
 
               torrent.finish();
             }

--- a/ttorrent-client/src/main/java/com/turn/ttorrent/client/SharedTorrent.java
+++ b/ttorrent-client/src/main/java/com/turn/ttorrent/client/SharedTorrent.java
@@ -243,7 +243,7 @@ public class SharedTorrent implements PeerActivityListener, TorrentMetadata, Tor
     initPieces();
 
     logger.debug("Analyzing local data for {} with {} threads...",
-            myTorrentMetadata.getDirectoryName(), TorrentCreator.HASHING_THREADS_COUNT);
+            myTorrentMetadata.getName(), TorrentCreator.HASHING_THREADS_COUNT);
     for (int idx = 0; idx < this.pieces.length; idx++) {
       byte[] hash = new byte[Constants.PIECE_HASH_SIZE];
       this.piecesHashes.get(hash);
@@ -268,7 +268,7 @@ public class SharedTorrent implements PeerActivityListener, TorrentMetadata, Tor
   }
 
   public synchronized void close() {
-    logger.trace("Closing torrent", myTorrentMetadata.getDirectoryName());
+    logger.trace("Closing torrent", myTorrentMetadata.getName());
     try {
       this.pieceStorage.close();
       isFileChannelOpen = false;
@@ -279,7 +279,7 @@ public class SharedTorrent implements PeerActivityListener, TorrentMetadata, Tor
   }
 
   public synchronized void closeFully() {
-    logger.trace("Closing torrent", myTorrentMetadata.getDirectoryName());
+    logger.trace("Closing torrent", myTorrentMetadata.getName());
     try {
       this.pieceStorage.closeFully();
       isFileChannelOpen = false;
@@ -743,6 +743,11 @@ public class SharedTorrent implements PeerActivityListener, TorrentMetadata, Tor
     return "SharedTorrent{" +
             Arrays.toString(TorrentUtils.getTorrentFileNames(myTorrentMetadata).toArray()) +
             "}";
+  }
+
+  @Override
+  public String getName() {
+    return myTorrentMetadata.getName();
   }
 
   @Override


### PR DESCRIPTION
Repeatedly serializing and de-serializing no longer changes the torrent hash. This can create hard to debug issues when saving, loading or transmitting `TorrentMetadata`. "Let's save the torrent. It is saved. But where is it? (I cannot find it by the hash.)"

There are two issues:
1. **Saving whether the torrent is private or not.** `TorrentSerializer` places a `info.private=1` **only if** the torrent is private otherwise it does not include that key. On the other hand, the newer `MetadataBuilder` would always include that key and put either a `0` or `1` depending if it private or not. 
According to bep_0027 :
> When generating a metainfo file, users denote a torrent as private by including the key-value pair "private=1" in the "info" dict of the torrent's metainfo file

There is nothing about "private=0", so I assume we can omit it like in the serializer.
2. **Single file torrents described in a multi-file format.** This has a valid use case like giving the file a custom path like in `testMultiFileModeWithOneFile`.  `TorrentSerializer`  treated a single file in multi-file mode a one in single-file mode. It did not have enough information to distinguish between the two case in scenario like in `testMultiFileModeWithOneFileSameName` where `fileName == directoryName`. There is a difference between `abc` and `abc/abc`.
Previously  `getDirectoryName` could also return the file name in single-file mode. Then it should be simply `getName`.