### PR TITLE
Performance tuning 1

### DIFF
--- a/common/src/main/java/com/turn/ttorrent/common/TorrentUtils.java
+++ b/common/src/main/java/com/turn/ttorrent/common/TorrentUtils.java
@@ -2,12 +2,22 @@ package com.turn.ttorrent.common;
 
 import org.apache.commons.codec.digest.DigestUtils;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 public final class TorrentUtils {
 
   private final static char[] HEX_SYMBOLS = "0123456789ABCDEF".toCharArray();
+  private static final Map<Integer, byte[]> COMMON_ZERO_HASHES = new HashMap<Integer, byte[]>();
+
+  static {
+//    COMMON_ZERO_HASHES.put(256 * 1024, calculateSha1Hash(new byte[256 * 1024]));
+//    COMMON_ZERO_HASHES.put(512 * 1024, calculateSha1Hash(new byte[512 * 1024]));
+//    COMMON_ZERO_HASHES.put(1024 * 1024, calculateSha1Hash(new byte[1024 * 1024]));
+    // precalculated values instead
+    COMMON_ZERO_HASHES.put(256 * 1024, new byte[]{46, 0, 15, -89, -24, 87, 89, -57, -12, -62, 84, -44, -39, -61, 62, -12, -127, -28, 89, -89});
+    COMMON_ZERO_HASHES.put(512 * 1024, new byte[]{106, 82, 30, 29, 42, 99, 44, 38, -27, 59, -125, -46, -52, 75, 14, -34, -49, -63, -26, -116});
+    COMMON_ZERO_HASHES.put(1024 * 1024, new byte[]{59, 113, -12, 63, -13, 15, 75, 21, -75, -51, -123, -35, -98, -107, -21, -57, -24, 78, -75, -93});
+  }
 
   /**
    * @param data for hashing
@@ -47,4 +57,12 @@ public final class TorrentUtils {
     return result;
   }
 
+  public static byte[] calculateZeroSha1Hash(int len) {
+    byte[] commonValue = COMMON_ZERO_HASHES.get(len);
+    if (commonValue != null) {
+      return commonValue;
+    } else {
+      return DigestUtils.sha1(new byte[len]);
+    }
+  }
 }

--- a/common/src/main/java/com/turn/ttorrent/common/TorrentUtils.java
+++ b/common/src/main/java/com/turn/ttorrent/common/TorrentUtils.java
@@ -2,22 +2,12 @@ package com.turn.ttorrent.common;
 
 import org.apache.commons.codec.digest.DigestUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class TorrentUtils {
 
   private final static char[] HEX_SYMBOLS = "0123456789ABCDEF".toCharArray();
-  private static final Map<Integer, byte[]> COMMON_ZERO_HASHES = new HashMap<Integer, byte[]>();
-
-  static {
-//    COMMON_ZERO_HASHES.put(256 * 1024, calculateSha1Hash(new byte[256 * 1024]));
-//    COMMON_ZERO_HASHES.put(512 * 1024, calculateSha1Hash(new byte[512 * 1024]));
-//    COMMON_ZERO_HASHES.put(1024 * 1024, calculateSha1Hash(new byte[1024 * 1024]));
-    // precalculated values instead
-    COMMON_ZERO_HASHES.put(256 * 1024, new byte[]{46, 0, 15, -89, -24, 87, 89, -57, -12, -62, 84, -44, -39, -61, 62, -12, -127, -28, 89, -89});
-    COMMON_ZERO_HASHES.put(512 * 1024, new byte[]{106, 82, 30, 29, 42, 99, 44, 38, -27, 59, -125, -46, -52, 75, 14, -34, -49, -63, -26, -116});
-    COMMON_ZERO_HASHES.put(1024 * 1024, new byte[]{59, 113, -12, 63, -13, 15, 75, 21, -75, -51, -123, -35, -98, -107, -21, -57, -24, 78, -75, -93});
-  }
 
   /**
    * @param data for hashing
@@ -57,12 +47,4 @@ public final class TorrentUtils {
     return result;
   }
 
-  public static byte[] calculateZeroSha1Hash(int len) {
-    byte[] commonValue = COMMON_ZERO_HASHES.get(len);
-    if (commonValue != null) {
-      return commonValue;
-    } else {
-      return DigestUtils.sha1(new byte[len]);
-    }
-  }
 }

--- a/ttorrent-client/src/main/java/com/turn/ttorrent/client/network/WorkingReceiver.java
+++ b/ttorrent-client/src/main/java/com/turn/ttorrent/client/network/WorkingReceiver.java
@@ -42,7 +42,7 @@ public class WorkingReceiver implements DataProcessor {
 
   @Override
   public DataProcessor processAndGetNext(ByteChannel socketChannel) throws IOException {
-    logger.trace("received data from channel", socketChannel);
+    logger.trace("received data from channel {}", socketChannel);
     if (pstrLength == -1) {
       messageBytes.limit(PeerMessage.MESSAGE_LENGTH_FIELD_SIZE);
       final int read;

--- a/ttorrent-client/src/main/java/com/turn/ttorrent/client/network/WorkingReceiver.java
+++ b/ttorrent-client/src/main/java/com/turn/ttorrent/client/network/WorkingReceiver.java
@@ -105,7 +105,7 @@ public class WorkingReceiver implements DataProcessor {
 
     final String hexInfoHash = peer.getHexInfoHash();
     SharedTorrent torrent = myContext.getTorrentsStorage().getTorrent(hexInfoHash);
-    if (torrent == null || !myContext.getTorrentsStorage().hasTorrent(hexInfoHash)) {
+    if (torrent == null) {
       logger.debug("torrent with hash {} for peer {} doesn't found in storage. Maybe somebody deletes it manually", hexInfoHash, peer);
       return new ShutdownAndRemovePeerProcessor(myPeerUID, myContext).processAndGetNext(socketChannel);
     }

--- a/ttorrent-client/src/main/java/com/turn/ttorrent/client/storage/FileCollectionStorage.java
+++ b/ttorrent-client/src/main/java/com/turn/ttorrent/client/storage/FileCollectionStorage.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2011-2012 Turn, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,7 +48,6 @@ public class FileCollectionStorage implements TorrentByteStorage {
 
   private final List<FileStorage> files;
   private final long size;
-  private volatile boolean myIsOpen;
 
   /**
    * Initialize a new multi-file torrent byte storage.
@@ -96,7 +95,6 @@ public class FileCollectionStorage implements TorrentByteStorage {
       if (!file.isOpen())
         file.open(seeder);
     }
-    myIsOpen = true;
   }
 
   @Override
@@ -137,11 +135,30 @@ public class FileCollectionStorage implements TorrentByteStorage {
   }
 
   @Override
+  public boolean isBlank(long position, long size) {
+    for (FileOffset fo : this.select(position, size)) {
+      if (!fo.file.isBlank(fo.offset, fo.length)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public boolean isBlank() {
+    for (FileStorage file : this.files) {
+      if (!file.isBlank()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
   public synchronized void close() throws IOException {
     for (FileStorage file : this.files) {
       file.close();
     }
-    myIsOpen = false;
   }
 
   @Override

--- a/ttorrent-client/src/main/java/com/turn/ttorrent/client/storage/FileStorage.java
+++ b/ttorrent-client/src/main/java/com/turn/ttorrent/client/storage/FileStorage.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2011-2012 Turn, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -56,11 +56,11 @@ public class FileStorage implements TorrentByteStorage {
   private FileChannel channel;
   private File current;
   private boolean myIsOpen = false;
+  private boolean isBlank;
 
   private final ReadWriteLock myLock = new ReentrantReadWriteLock();
 
-  public FileStorage(File file, long offset, long size)
-          throws IOException {
+  public FileStorage(File file, long offset, long size) {
     this.target = file;
     this.offset = offset;
     this.size = size;
@@ -83,14 +83,17 @@ public class FileStorage implements TorrentByteStorage {
           logger.debug("Partial download found at {}. Continuing...",
                   this.partial.getAbsolutePath());
           this.current = this.partial;
+          this.isBlank = false;
         } else if (!this.target.exists()) {
           logger.debug("Downloading new file to {}...",
                   this.partial.getAbsolutePath());
           this.current = this.partial;
+          this.isBlank = true;
         } else {
           logger.debug("Using existing file {}.",
                   this.target.getAbsolutePath());
           this.current = this.target;
+          this.isBlank = false;
         }
         this.raf = new RandomAccessFile(this.current, "rw");
         this.raf.setLength(this.size);
@@ -146,6 +149,7 @@ public class FileStorage implements TorrentByteStorage {
     try {
       myLock.writeLock().lock();
       int requested = buffer.remaining();
+      this.isBlank = false;
 
       if (position + requested > this.size) {
         throw new IllegalArgumentException("Invalid storage write request!");
@@ -222,6 +226,21 @@ public class FileStorage implements TorrentByteStorage {
     try {
       myLock.readLock().lock();
       return myIsOpen;
+    } finally {
+      myLock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public boolean isBlank(long position, long size) {
+      return isBlank();
+  }
+
+  @Override
+  public boolean isBlank() {
+    try {
+      myLock.readLock().lock();
+      return isBlank;
     } finally {
       myLock.readLock().unlock();
     }

--- a/ttorrent-client/src/main/java/com/turn/ttorrent/client/storage/TorrentByteStorage.java
+++ b/ttorrent-client/src/main/java/com/turn/ttorrent/client/storage/TorrentByteStorage.java
@@ -93,6 +93,19 @@ public interface TorrentByteStorage extends Closeable {
   boolean isFinished();
 
   /**
+   * @param position Position in the underlying byte storage to write the block at.
+   * @param size Size of region to check.
+   * @return true if the region starting with positions only contains zeros
+   */
+  boolean isBlank(long position, long size);
+
+  /**
+   *
+   * @return true if the enter storage only contains zeros
+   */
+  boolean isBlank();
+
+  /**
    * Delete byte storage information
    */
   void delete() throws IOException;

--- a/ttorrent-client/src/test/java/com/turn/ttorrent/client/ByteArrayStorage.java
+++ b/ttorrent-client/src/test/java/com/turn/ttorrent/client/ByteArrayStorage.java
@@ -9,9 +9,11 @@ public class ByteArrayStorage implements TorrentByteStorage {
 
   private final byte[] array;
   private boolean finished = false;
+  private boolean isBlank;
 
   public ByteArrayStorage(int maxSize) {
     array = new byte[maxSize];
+    isBlank = true;
   }
 
   @Override
@@ -41,6 +43,7 @@ public class ByteArrayStorage implements TorrentByteStorage {
     byte[] toWrite = new byte[bytesCount];
     block.get(toWrite);
     System.arraycopy(toWrite, 0, array, pos, toWrite.length);
+    isBlank = false;
     return bytesCount;
   }
 
@@ -52,6 +55,16 @@ public class ByteArrayStorage implements TorrentByteStorage {
   @Override
   public boolean isFinished() {
     return finished;
+  }
+
+  @Override
+  public boolean isBlank(long position, long size) {
+    return isBlank;
+  }
+
+  @Override
+  public boolean isBlank() {
+    return isBlank;
   }
 
   @Override

--- a/ttorrent-client/src/test/java/com/turn/ttorrent/client/storage/FairPieceStorageFactoryTest.java
+++ b/ttorrent-client/src/test/java/com/turn/ttorrent/client/storage/FairPieceStorageFactoryTest.java
@@ -71,6 +71,16 @@ public class FairPieceStorageFactoryTest {
       }
 
       @Override
+      public boolean isBlank(long position, long size) {
+        return false;
+      }
+
+      @Override
+      public boolean isBlank() {
+        return false;
+      }
+
+      @Override
       public void delete() {
         throw notImplemented();
       }


### PR DESCRIPTION
## Significantly sped up downloading 
 When downloading `FairPieceStorageFactory.createStorage` could not tell the difference between a partial download and a completely blank piece it just created. Then it would compute SHA-1 hash in both cases.

~~Now instead of computing a hash of, for example, 512*1024  zeros for each of the pieces, it knows that it is blank and will use the pre-computed value. Pre-computed sha-1 hashes for empty (all zeros) blocks of common sizes (256KB, 512KB and 1MB as seen in multiple blog post).
You can always add more values to cover more cases, but I did not as the common ones should be a great improvement already. Each pre-computed value hash takes `20+4` bytes + HashMap overhead. It might be worth adding all the powers of two, but that still leaves the last piece which is likely not a power of two. Adding every possible hash would take gigabytes which is too much.~~

Edited:
If we have a newly created blank piece we assume that the torrent does not have a blank piece and download that piece without looking at the hash.

## Misc
Also made a small performance improvement by eliminating an extra read from `TorrentsStorage` in `WorkingReceiver`.